### PR TITLE
fix(ZMS-3080): catching null waiting times when queue is empty

### DIFF
--- a/zmscalldisplay/src/Zmscalldisplay/Info.php
+++ b/zmscalldisplay/src/Zmscalldisplay/Info.php
@@ -14,7 +14,6 @@ use BO\Zmsentities\Collection\QueueList as Collection;
 
 class Info extends BaseController
 {
-
     /**
      * @SuppressWarnings(UnusedFormalParameter)
      * @return ResponseInterface
@@ -28,31 +27,22 @@ class Info extends BaseController
             ->readPostResult('/calldisplay/queue/', $calldisplay->getEntity(false))
             ->getCollection();
 
-        $waitingClientsBefore = $queueListFull
+        $filteredQueue = $queueListFull
             ->withoutStatus(Collection::STATUS_FAKE)
-            ->getCountWithWaitingTime()
-            ->count();
+            ->getCountWithWaitingTime();
 
-        $waitingTimeFull = $queueListFull
-            ->withoutStatus(Collection::STATUS_FAKE)
-            ->getCountWithWaitingTime()
-            ->getLast()
-            ->waitingTimeEstimate;
-
-        $waitingTimeOptim = $queueListFull
-            ->withoutStatus(Collection::STATUS_FAKE)
-            ->getCountWithWaitingTime()
-            ->getLast()
-            ->waitingTimeOptimistic;
+        $lastClient = $filteredQueue->getLast();
+        $waitingTimeFull = $lastClient ? $lastClient->waitingTimeEstimate : 0;
+        $waitingTimeOptim = $lastClient ? $lastClient->waitingTimeOptimistic : 0;
 
         return Render::withHtml(
             $response,
             'element/tempWaitingValues.twig',
             array(
                 'calldisplay' => $calldisplay,
-                'waitingClients' => $waitingClientsBefore,
+                'waitingClients' => $filteredQueue->count(),
                 'waitingTime' => $waitingTimeFull,
-                'waitingTimeOptimistic' => $waitingTimeOptim,
+                'waitingTimeOptimistic' => $waitingTimeOptim
             )
         );
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in calculating the number of waiting clients and their estimated waiting times.
- **Refactor**
	- Enhanced clarity and reduced redundancy in the logic for processing client wait times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->